### PR TITLE
chore: renovate lmdb-rs for bazelization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ lmdb-rkv-sys = { path = "./lmdb-sys" }
 
 [dev-dependencies]
 rand = "0.4"
-tempdir = "0.3"
+tempfile = "3.3.0"
 
 [features]
 default = []

--- a/lmdb-sys/build.rs
+++ b/lmdb-sys/build.rs
@@ -48,38 +48,40 @@ fn main() {
     println!("cargo:rerun-if-changed=src/lib.rs");
     generate::generate();
 
-    let mut lmdb = PathBuf::from(&env::var("CARGO_MANIFEST_DIR").unwrap());
-    lmdb.push("lmdb");
-    lmdb.push("libraries");
-    lmdb.push("liblmdb");
-
     if cfg!(feature = "with-fuzzer") && cfg!(feature = "with-fuzzer-no-link") {
         warn!("Features `with-fuzzer` and `with-fuzzer-no-link` are mutually exclusive.");
         warn!("Building with `-fsanitize=fuzzer`.");
     }
 
-    if pkg_config::probe_library("lmdb").is_err() {
-        let mut builder = cc::Build::new();
+    if let Err(_) = std::env::var("LMDB_NO_BUILD") {
+        if pkg_config::probe_library("lmdb").is_err() {
+            let mut lmdb = PathBuf::from(&env::var("CARGO_MANIFEST_DIR").unwrap());
+            lmdb.push("lmdb");
+            lmdb.push("libraries");
+            lmdb.push("liblmdb");
 
-        builder
-            .define("MDB_IDL_LOGN", Some(MDB_IDL_LOGN.to_string().as_str()))
-            .file(lmdb.join("mdb.c"))
-            .file(lmdb.join("midl.c"))
-            // https://github.com/mozilla/lmdb/blob/b7df2cac50fb41e8bd16aab4cc5fd167be9e032a/libraries/liblmdb/Makefile#L23
-            .flag_if_supported("-Wno-unused-parameter")
-            .flag_if_supported("-Wbad-function-cast")
-            .flag_if_supported("-Wuninitialized");
+            let mut builder = cc::Build::new();
 
-        if env::var("CARGO_FEATURE_WITH_ASAN").is_ok() {
-            builder.flag("-fsanitize=address");
+            builder
+                .define("MDB_IDL_LOGN", Some(MDB_IDL_LOGN.to_string().as_str()))
+                .file(lmdb.join("mdb.c"))
+                .file(lmdb.join("midl.c"))
+                // https://github.com/mozilla/lmdb/blob/b7df2cac50fb41e8bd16aab4cc5fd167be9e032a/libraries/liblmdb/Makefile#L23
+                .flag_if_supported("-Wno-unused-parameter")
+                .flag_if_supported("-Wbad-function-cast")
+                .flag_if_supported("-Wuninitialized");
+
+            if env::var("CARGO_FEATURE_WITH_ASAN").is_ok() {
+                builder.flag("-fsanitize=address");
+            }
+
+            if env::var("CARGO_FEATURE_WITH_FUZZER").is_ok() {
+                builder.flag("-fsanitize=fuzzer");
+            } else if env::var("CARGO_FEATURE_WITH_FUZZER_NO_LINK").is_ok() {
+                builder.flag("-fsanitize=fuzzer-no-link");
+            }
+
+            builder.compile("liblmdb.a")
         }
-
-        if env::var("CARGO_FEATURE_WITH_FUZZER").is_ok() {
-            builder.flag("-fsanitize=fuzzer");
-        } else if env::var("CARGO_FEATURE_WITH_FUZZER_NO_LINK").is_ok() {
-            builder.flag("-fsanitize=fuzzer-no-link");
-        }
-
-        builder.compile("liblmdb.a")
     }
 }

--- a/lmdb-sys/src/lib.rs
+++ b/lmdb-sys/src/lib.rs
@@ -19,4 +19,4 @@ pub type mdb_filehandle_t = ::libc::c_int;
 #[allow(non_camel_case_types)]
 pub type mdb_filehandle_t = *mut ::libc::c_void;
 
-include!("bindings.rs");
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,25 +1,10 @@
 use std::marker::PhantomData;
-use std::{
-    fmt,
-    mem,
-    ptr,
-    result,
-    slice,
-};
+use std::{fmt, mem, ptr, result, slice};
 
-use libc::{
-    c_uint,
-    c_void,
-    size_t,
-    EINVAL,
-};
+use libc::{c_uint, c_void, size_t, EINVAL};
 
 use database::Database;
-use error::{
-    lmdb_result,
-    Error,
-    Result,
-};
+use error::{lmdb_result, Error, Result};
 use ffi;
 use flags::WriteFlags;
 use transaction::Transaction;
@@ -420,7 +405,7 @@ impl<'txn> Iterator for IterDup<'txn> {
 
 #[cfg(test)]
 mod test {
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::*;
     use environment::*;
@@ -429,7 +414,7 @@ mod test {
 
     #[test]
     fn test_get() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().open(dir.path()).unwrap();
         let db = env.open_db(None).unwrap();
 
@@ -451,7 +436,7 @@ mod test {
 
     #[test]
     fn test_get_dup() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().open(dir.path()).unwrap();
         let db = env.create_db(None, DatabaseFlags::DUP_SORT).unwrap();
 
@@ -486,7 +471,7 @@ mod test {
 
     #[test]
     fn test_get_dupfixed() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().open(dir.path()).unwrap();
         let db = env.create_db(None, DatabaseFlags::DUP_SORT | DatabaseFlags::DUP_FIXED).unwrap();
 
@@ -506,7 +491,7 @@ mod test {
 
     #[test]
     fn test_iter() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().open(dir.path()).unwrap();
         let db = env.open_db(None).unwrap();
 
@@ -559,7 +544,7 @@ mod test {
 
     #[test]
     fn test_iter_empty_database() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().open(dir.path()).unwrap();
         let db = env.open_db(None).unwrap();
         let txn = env.begin_ro_txn().unwrap();
@@ -572,7 +557,7 @@ mod test {
 
     #[test]
     fn test_iter_empty_dup_database() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().open(dir.path()).unwrap();
         let db = env.create_db(None, DatabaseFlags::DUP_SORT).unwrap();
         let txn = env.begin_ro_txn().unwrap();
@@ -589,7 +574,7 @@ mod test {
 
     #[test]
     fn test_iter_dup() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().open(dir.path()).unwrap();
         let db = env.create_db(None, DatabaseFlags::DUP_SORT).unwrap();
 
@@ -658,7 +643,7 @@ mod test {
 
     #[test]
     fn test_iter_del_get() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().open(dir.path()).unwrap();
         let db = env.create_db(None, DatabaseFlags::DUP_SORT).unwrap();
 
@@ -696,7 +681,7 @@ mod test {
 
     #[test]
     fn test_put_del() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().open(dir.path()).unwrap();
         let db = env.open_db(None).unwrap();
 

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,7 +1,4 @@
-use libc::{
-    c_uint,
-    size_t,
-};
+use libc::{c_uint, size_t};
 use std::ffi::CString;
 #[cfg(windows)]
 use std::ffi::OsStr;
@@ -9,36 +6,17 @@ use std::ffi::OsStr;
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use std::sync::Mutex;
-use std::{
-    fmt,
-    mem,
-    ptr,
-    result,
-};
+use std::{fmt, mem, ptr, result};
 
 use ffi;
 
-use byteorder::{
-    ByteOrder,
-    NativeEndian,
-};
+use byteorder::{ByteOrder, NativeEndian};
 
 use cursor::Cursor;
 use database::Database;
-use error::{
-    lmdb_result,
-    Error,
-    Result,
-};
-use flags::{
-    DatabaseFlags,
-    EnvironmentFlags,
-};
-use transaction::{
-    RoTransaction,
-    RwTransaction,
-    Transaction,
-};
+use error::{lmdb_result, Error, Result};
+use flags::{DatabaseFlags, EnvironmentFlags};
+use transaction::{RoTransaction, RwTransaction, Transaction};
 
 #[cfg(windows)]
 /// Adding a 'missing' trait from windows OsStrExt
@@ -487,11 +465,8 @@ mod test {
 
     extern crate byteorder;
 
-    use self::byteorder::{
-        ByteOrder,
-        LittleEndian,
-    };
-    use tempdir::TempDir;
+    use self::byteorder::{ByteOrder, LittleEndian};
+    use tempfile::Builder;
 
     use flags::*;
 
@@ -499,7 +474,7 @@ mod test {
 
     #[test]
     fn test_open() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
 
         // opening non-existent env with read-only should fail
         assert!(Environment::new().set_flags(EnvironmentFlags::READ_ONLY).open(dir.path()).is_err());
@@ -513,7 +488,7 @@ mod test {
 
     #[test]
     fn test_begin_txn() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
 
         {
             // writable environment
@@ -534,7 +509,7 @@ mod test {
 
     #[test]
     fn test_open_db() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().set_max_dbs(1).open(dir.path()).unwrap();
 
         assert!(env.open_db(None).is_ok());
@@ -543,7 +518,7 @@ mod test {
 
     #[test]
     fn test_create_db() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().set_max_dbs(11).open(dir.path()).unwrap();
         assert!(env.open_db(Some("testdb")).is_err());
         assert!(env.create_db(Some("testdb"), DatabaseFlags::empty()).is_ok());
@@ -552,7 +527,7 @@ mod test {
 
     #[test]
     fn test_close_database() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let mut env = Environment::new().set_max_dbs(10).open(dir.path()).unwrap();
 
         let db = env.create_db(Some("db"), DatabaseFlags::empty()).unwrap();
@@ -564,7 +539,7 @@ mod test {
 
     #[test]
     fn test_sync() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         {
             let env = Environment::new().open(dir.path()).unwrap();
             assert!(env.sync(true).is_ok());
@@ -577,7 +552,7 @@ mod test {
 
     #[test]
     fn test_stat() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().open(dir.path()).unwrap();
 
         // Stats should be empty initially.
@@ -613,7 +588,7 @@ mod test {
     #[test]
     fn test_info() {
         let map_size = 1024 * 1024;
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().set_map_size(map_size).open(dir.path()).unwrap();
 
         let info = env.info().unwrap();
@@ -627,7 +602,7 @@ mod test {
 
     #[test]
     fn test_freelist() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().open(dir.path()).unwrap();
 
         let db = env.open_db(None).unwrap();
@@ -653,7 +628,7 @@ mod test {
 
     #[test]
     fn test_set_map_size() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().open(dir.path()).unwrap();
 
         let mut info = env.info().unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,7 @@
 use libc::c_int;
-use std::error::Error as StdError;
 use std::ffi::CStr;
 use std::os::raw::c_char;
-use std::{
-    fmt,
-    result,
-    str,
-};
+use std::{fmt, result, str};
 
 use ffi;
 
@@ -116,17 +111,12 @@ impl Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.description())
-    }
-}
-
-impl StdError for Error {
-    fn description(&self) -> &str {
-        unsafe {
+        let description = unsafe {
             // This is safe since the error messages returned from mdb_strerror are static.
             let err: *const c_char = ffi::mdb_strerror(self.to_err_code()) as *const c_char;
             str::from_utf8_unchecked(CStr::from_ptr(err).to_bytes())
-        }
+        };
+        write!(fmt, "{}", description)
     }
 }
 
@@ -144,13 +134,11 @@ pub fn lmdb_result(err_code: c_int) -> Result<()> {
 #[cfg(test)]
 mod test {
 
-    use std::error::Error as StdError;
-
     use super::*;
 
     #[test]
     fn test_description() {
-        assert_eq!("Permission denied", Error::from_err_code(13).description());
-        assert_eq!("MDB_NOTFOUND: No matching key/data pair found", Error::NotFound.description());
+        assert_eq!("Permission denied", Error::from_err_code(13).to_string());
+        assert_eq!("MDB_NOTFOUND: No matching key/data pair found", Error::NotFound.to_string());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,35 +9,16 @@ extern crate libc;
 extern crate lmdb_sys as ffi;
 
 #[cfg(test)]
-extern crate tempdir;
+extern crate tempfile;
 #[macro_use]
 extern crate bitflags;
 
-pub use cursor::{
-    Cursor,
-    Iter,
-    IterDup,
-    RoCursor,
-    RwCursor,
-};
+pub use cursor::{Cursor, Iter, IterDup, RoCursor, RwCursor};
 pub use database::Database;
-pub use environment::{
-    Environment,
-    EnvironmentBuilder,
-    Info,
-    Stat,
-};
-pub use error::{
-    Error,
-    Result,
-};
+pub use environment::{Environment, EnvironmentBuilder, Info, Stat};
+pub use error::{Error, Result};
 pub use flags::*;
-pub use transaction::{
-    InactiveTransaction,
-    RoTransaction,
-    RwTransaction,
-    Transaction,
-};
+pub use transaction::{InactiveTransaction, RoTransaction, RwTransaction, Transaction};
 
 macro_rules! lmdb_try {
     ($expr:expr) => {{
@@ -70,11 +51,8 @@ mod transaction;
 #[cfg(test)]
 mod test_utils {
 
-    use byteorder::{
-        ByteOrder,
-        LittleEndian,
-    };
-    use tempdir::TempDir;
+    use byteorder::{ByteOrder, LittleEndian};
+    use tempfile::Builder;
 
     use super::*;
 
@@ -85,7 +63,7 @@ mod test_utils {
     fn issue_21_regression() {
         const HEIGHT_KEY: [u8; 1] = [0];
 
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
 
         let env = {
             let mut builder = Environment::new();

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,38 +1,14 @@
-use libc::{
-    c_uint,
-    c_void,
-    size_t,
-};
+use libc::{c_uint, c_void, size_t};
 use std::marker::PhantomData;
-use std::{
-    fmt,
-    mem,
-    ptr,
-    result,
-    slice,
-};
+use std::{fmt, mem, ptr, result, slice};
 
 use ffi;
 
-use cursor::{
-    RoCursor,
-    RwCursor,
-};
+use cursor::{RoCursor, RwCursor};
 use database::Database;
-use environment::{
-    Environment,
-    Stat,
-};
-use error::{
-    lmdb_result,
-    Error,
-    Result,
-};
-use flags::{
-    DatabaseFlags,
-    EnvironmentFlags,
-    WriteFlags,
-};
+use environment::{Environment, Stat};
+use error::{lmdb_result, Error, Result};
+use flags::{DatabaseFlags, EnvironmentFlags, WriteFlags};
 
 /// An LMDB transaction.
 ///
@@ -422,16 +398,10 @@ impl<'env> Transaction for RwTransaction<'env> {
 mod test {
 
     use std::io::Write;
-    use std::sync::{
-        Arc,
-        Barrier,
-    };
-    use std::thread::{
-        self,
-        JoinHandle,
-    };
+    use std::sync::{Arc, Barrier};
+    use std::thread::{self, JoinHandle};
 
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::*;
     use cursor::Cursor;
@@ -440,7 +410,7 @@ mod test {
 
     #[test]
     fn test_put_get_del() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().open(dir.path()).unwrap();
         let db = env.open_db(None).unwrap();
 
@@ -462,7 +432,7 @@ mod test {
 
     #[test]
     fn test_put_get_del_multi() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().open(dir.path()).unwrap();
         let db = env.create_db(None, DatabaseFlags::DUP_SORT).unwrap();
 
@@ -507,7 +477,7 @@ mod test {
 
     #[test]
     fn test_reserve() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().open(dir.path()).unwrap();
         let db = env.open_db(None).unwrap();
 
@@ -528,7 +498,7 @@ mod test {
 
     #[test]
     fn test_inactive_txn() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().open(dir.path()).unwrap();
         let db = env.open_db(None).unwrap();
 
@@ -546,7 +516,7 @@ mod test {
 
     #[test]
     fn test_nested_txn() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().open(dir.path()).unwrap();
         let db = env.open_db(None).unwrap();
 
@@ -566,7 +536,7 @@ mod test {
 
     #[test]
     fn test_clear_db() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().open(dir.path()).unwrap();
         let db = env.open_db(None).unwrap();
 
@@ -588,7 +558,7 @@ mod test {
 
     #[test]
     fn test_drop_db() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().set_max_dbs(2).open(dir.path()).unwrap();
         let db = env.create_db(Some("test"), DatabaseFlags::empty()).unwrap();
 
@@ -610,7 +580,7 @@ mod test {
 
     #[test]
     fn test_concurrent_readers_single_writer() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env: Arc<Environment> = Arc::new(Environment::new().open(dir.path()).unwrap());
 
         let n = 10usize; // Number of concurrent readers
@@ -652,7 +622,7 @@ mod test {
 
     #[test]
     fn test_concurrent_writers() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Arc::new(Environment::new().open(dir.path()).unwrap());
 
         let n = 10usize; // Number of concurrent writers
@@ -683,7 +653,7 @@ mod test {
 
     #[test]
     fn test_stat() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().open(dir.path()).unwrap();
         let db = env.create_db(None, DatabaseFlags::empty()).unwrap();
 
@@ -725,7 +695,7 @@ mod test {
 
     #[test]
     fn test_stat_dupsort() {
-        let dir = TempDir::new("test").unwrap();
+        let dir = Builder::new().prefix("test").tempdir().unwrap();
         let env = Environment::new().open(dir.path()).unwrap();
         let db = env.create_db(None, DatabaseFlags::DUP_SORT).unwrap();
 


### PR DESCRIPTION
This change updates the library to simplify migrating the build to Bazel:

  * Do not generate code to source tree in the build script, use `OUT_DIR`
    instead.

  * If `LMDB_H_PATH` env variable is defined, use it find `lmdb.h` header
    for bindgen.

  * If `LMDB_NO_BUILD` env variable is defined, do not try to build
    `liblmdb.a`. We can fetch and build `liblmdb.a` with Bazel.

  * Fix deprecation warnings (e.g., `Error::description`) and replace obsolete crates
    (`tempdir` -> `tempfile`).